### PR TITLE
Add EXPOSE instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,5 @@ RUN chmod -R 755 /var/www/html
 RUN chmod 777 /var/www/html/user1.txt /var/www/html/user2.txt /var/www/html/comments.txt /var/www/html/management.txt
 ADD php.ini /etc/php5/apache2/php.ini
 ENV DEBIAN_FRONTEND noninteractive
+EXPOSE 80
 CMD /usr/sbin/apache2ctl -D FOREGROUND


### PR DESCRIPTION
The `EXPOSE` instruction is required to open up ports for communication between containers, for example when using Docker Compose.

I am using this with [`jwilder/nginx-proxy`](https://github.com/jwilder/nginx-proxy), and adding the `EXPOSE` instruction did the trick.